### PR TITLE
stop possible divide by zero during normalization

### DIFF
--- a/src/gui/controls/Visualizer.cpp
+++ b/src/gui/controls/Visualizer.cpp
@@ -55,7 +55,7 @@ bool ebox::Visualizer::process() {
             if (index > m_samplesSize / prescaler) break;
             float scalefac = exp(octaves * (float) index / (m_samplesSize / prescaler));
             /// Normalize and scale logarithimcally - because that is how we work
-            val = (val / maxval) * scalefac;
+            val = (val / (maxval == 0 ? 1 : maxval)) * scalefac;
             index++;
         }
         /// Draw frequency spectrum


### PR DESCRIPTION
Not sure, but the only possible bug I could see without actually experiencing the bug on my system. 